### PR TITLE
Clean up any inline position styles on destroy

### DIFF
--- a/jquery.drag-n-crop.js
+++ b/jquery.drag-n-crop.js
@@ -112,6 +112,7 @@
                               '.' + this.classes.instruction).remove();
           this.element.removeClass(this.classes.horizontal)
                       .removeClass(this.classes.vertical);
+          this.element.css({position: '', top: '', left: ''});    
         },
 
         getPosition: function() {


### PR DESCRIPTION
There are situations where the the image is changed and the plug in needs to be destroyed and re-created. In this case, if the image format is very different, it may be displayed incorrectly due to the position styles being persisted after the plugin is destroyed.
